### PR TITLE
Implemented load_data functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+Datasets/
+Indoor-scene-recognition/

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ Indoor-scene-recognition/
 
 data/*
 !data/README.md
+
+__pycache__

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 Datasets/
 Indoor-scene-recognition/
+
+data/*
+!data/README.md

--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
 Image Inpainting for CSC420
+
+
+Data will not be pushed to GitHub. We will maintain data each in our local repo. To start development, download the data from [here](http://web.mit.edu/torralba/www/indoor.html?fbclid=IwAR0_7QdqHvB-YT3R-ylltLE3F3Ob_tgQzPRpxi1xKNV7sYQx6cfsIuzSkXU) and save under "data/" dir following the format:
+
+
+TO BE DETERMINED
+

--- a/README.md
+++ b/README.md
@@ -6,3 +6,7 @@ Data will not be pushed to GitHub. We will maintain data each in our local repo.
 
 TO BE DETERMINED
 
+
+
+For me:
+Ružić’s patch-based approach[3] because compared to other patch-based techniques, this algorithm makes use of the Markov Random Field to improve the computation efficiency

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-Image Inpainting for CSC420
+# Image Inpainting for CSC420
+
+See [./data dir](./data/README.md) for notes on maintaining data
 
 
 
-
-
-For me:
-Ružić’s patch-based approach[3] because compared to other patch-based techniques, this algorithm makes use of the Markov Random Field to improve the computation efficiency
+Notes on Patched Based Method:
+We will implement Ružić’s patch-based approach[3] because compared to other patch-based techniques, this algorithm makes use of the Markov Random Field to improve the computation efficiency

--- a/README.md
+++ b/README.md
@@ -1,10 +1,6 @@
 Image Inpainting for CSC420
 
 
-Data will not be pushed to GitHub. We will maintain data each in our local repo. To start development, download the data from [here](http://web.mit.edu/torralba/www/indoor.html?fbclid=IwAR0_7QdqHvB-YT3R-ylltLE3F3Ob_tgQzPRpxi1xKNV7sYQx6cfsIuzSkXU) and save under "data/" dir following the format:
-
-
-TO BE DETERMINED
 
 
 

--- a/data/README.md
+++ b/data/README.md
@@ -1,0 +1,1 @@
+Directory containing data

--- a/data/README.md
+++ b/data/README.md
@@ -1,8 +1,6 @@
 # Directory Containing Data
 
 Data will not be pushed to GitHub. We will maintain data each in our local repo. To start development, download the data from [here](http://web.mit.edu/torralba/www/indoor.html?fbclid=IwAR0_7QdqHvB-YT3R-ylltLE3F3Ob_tgQzPRpxi1xKNV7sYQx6cfsIuzSkXU) and save (untarred files) under "data/" dir.
-Per source of data: "All images have a minimum resolution of 200 pixels in the smallest axis"
-
 
 See "playground.py" if unsure how to untar.
 
@@ -34,3 +32,10 @@ File structure in your local repo should look like:
 
 
 To access the data, use the functions in load_data.py
+
+
+Note that all images have different dimensions. However, per source of data, "All images have a minimum resolution of 200 pixels in the smallest axis". 
+Using the data preparation technique mentioned [here](https://machinelearningmastery.com/best-practices-for-preparing-and-augmenting-image-data-for-convolutional-neural-networks/), when loading the data, the images will be truncated to 200x200 (to account for the smallest possible image). 
+
+If an image is square => A simple downsize to 200x200.
+If an image is rectangle, we know the smallest axis is at least 200. Resize the rectangle such that the smallest axis is now 200. The larger dimension will be cropped in the center.

--- a/data/README.md
+++ b/data/README.md
@@ -1,8 +1,10 @@
 # Directory Containing Data
 
 Data will not be pushed to GitHub. We will maintain data each in our local repo. To start development, download the data from [here](http://web.mit.edu/torralba/www/indoor.html?fbclid=IwAR0_7QdqHvB-YT3R-ylltLE3F3Ob_tgQzPRpxi1xKNV7sYQx6cfsIuzSkXU) and save (untarred files) under "data/" dir.
+Per source of data: "All images have a minimum resolution of 200 pixels in the smallest axis"
 
-See "playground.py" if unsure how to untar
+
+See "playground.py" if unsure how to untar.
 
 File structure in your local repo should look like:
 

--- a/data/README.md
+++ b/data/README.md
@@ -27,7 +27,9 @@ File structure in your local repo should look like:
                 2b.jpg
             ...
         README.md
+        TestImages.npy    <= generated after load_data is called
         TestImages.txt
+        TrainImages.npy   <= generated after load_data is called
         TrainImages.txt
 
 

--- a/data/README.md
+++ b/data/README.md
@@ -6,29 +6,29 @@ See "playground.py" if unsure how to untar
 
 File structure in your local repo should look like:
 
-data/
-    Annotations/
-        category1/
-            1a.xml
-            1b.xml
+    data/
+        Annotations/
+            category1/
+                1a.xml
+                1b.xml
+                ...
+            category2/
+                2a.xml
+                2b.xml
+                ...
             ...
-        category2/
-            2a.xml
-            2b.xml
+        Images/
+            category1/
+                1a.jpg
+                1b.jpg
+                ...
+            category2/
+                2a.jpg
+                2b.jpg
             ...
-        ...
-    Images/
-        category1/
-            1a.jpg
-            1b.jpg
-            ...
-        category2/
-            2a.jpg
-            2b.jpg
-        ...
-    README.md
-    TestImages.txt
-    TrainImages.txt
+        README.md
+        TestImages.txt
+        TrainImages.txt
 
 
 To access the data, use the functions in load_data.py

--- a/data/README.md
+++ b/data/README.md
@@ -39,3 +39,5 @@ Using the data preparation technique mentioned [here](https://machinelearningmas
 
 If an image is square => A simple downsize to 200x200.
 If an image is rectangle, we know the smallest axis is at least 200. Resize the rectangle such that the smallest axis is now 200. The larger dimension will be cropped in the center.
+
+Therefore the normalized images will be 200x200x3, where the last axis denotes the color channels BGR.

--- a/data/README.md
+++ b/data/README.md
@@ -1,1 +1,34 @@
-Directory containing data
+# Directory Containing Data
+
+Data will not be pushed to GitHub. We will maintain data each in our local repo. To start development, download the data from [here](http://web.mit.edu/torralba/www/indoor.html?fbclid=IwAR0_7QdqHvB-YT3R-ylltLE3F3Ob_tgQzPRpxi1xKNV7sYQx6cfsIuzSkXU) and save (untarred files) under "data/" dir.
+
+See "playground.py" if unsure how to untar
+
+File structure in your local repo should look like:
+
+data/
+    Annotations/
+        category1/
+            1a.xml
+            1b.xml
+            ...
+        category2/
+            2a.xml
+            2b.xml
+            ...
+        ...
+    Images/
+        category1/
+            1a.jpg
+            1b.jpg
+            ...
+        category2/
+            2a.jpg
+            2b.jpg
+        ...
+    README.md
+    TestImages.txt
+    TrainImages.txt
+
+
+To access the data, use the functions in load_data.py

--- a/load_data.py
+++ b/load_data.py
@@ -1,15 +1,16 @@
 import numpy as np
 import os
+import cv2
 
-data_dir = './data/'
+data_dir = 'data'
 
 def get_img_paths(name):
     '''
         Returns a list of image paths which are found in name file
     '''
     ret = []
-    with open(data_dir+name, 'r') as reader:
-        ret = reader.readlines()
+    with open(os.path.join(data_dir,name), 'r') as reader:
+        ret = reader.read().splitlines()
     return ret
 
 
@@ -23,6 +24,32 @@ def load_annotations(paths):
     return []
 
 
+def load_normalized_img(path):
+    '''
+        Return the image found at path as an array-like matrix
+
+        The returned image will be normalized to the dimensions 200x200x3 (3 color channels)
+    '''
+    full_path = os.path.abspath(os.path.join(data_dir, "Images", path))
+    img = cv2.imread(full_path)
+    if img is None:
+        print(full_path)
+        print(os.path.exists(full_path))
+    # Resize image such that the smallest axis is downsized to 200
+    h, w = img.shape[0], img.shape[1]
+    if h < w: # Height is shorter than width
+        shrink_ratio = 200.0/h
+    else: # Width is shorter than height
+        shrink_ratio = 200.0/w
+    new_h = int(shrink_ratio*h)
+    new_w = int(shrink_ratio*w)
+    resize_img = cv2.resize(img, (new_w,new_h)) # 200xW or Hx200, where W/H is greater than 200
+    # Crop the center 200x200
+    start_h = (new_h-200)//2
+    start_w = (new_w-200)//2
+    return resize_img[start_h:start_h+200, start_w:start_w+200]
+
+
 def load_images(paths):
     '''
         Returns a list of images found in paths.
@@ -33,8 +60,10 @@ def load_images(paths):
         After normalization, the images will have dimension 200x200.
         See data/README.md for more info
     '''
-    # TODO: Not sure if the images should be truncated to a common size, or padded, etc etc
-    return []
+    images = np.zeros((len(paths), 200, 200, 3), dtype=np.uint8) # NumImagesx200x200x3 => 3 color channels
+    for path_i in range(len(paths)):
+        images[path_i] = load_normalized_img(os.path.normpath(paths[path_i]))
+    return images
 
 
 def load_train_data():

--- a/load_data.py
+++ b/load_data.py
@@ -19,6 +19,7 @@ def load_annotations(paths):
         Per source of data:
         "A subset of the images are segmented and annotated with the objects that they contain. The annotations are in LabelMe format."
     '''
+    # TODO: Annotations maybe not needed for our task?
     return []
 
 
@@ -30,6 +31,7 @@ def load_images(paths):
         Per source of data:
         "All images have a minimum resolution of 200 pixels in the smallest axis"
     '''
+    # TODO: Not sure if the images should be truncated to a common size, or padded, etc etc
     return []
 
 

--- a/load_data.py
+++ b/load_data.py
@@ -30,6 +30,8 @@ def load_images(paths):
             The dimensions will be normalized before returning
         Per source of data:
         "All images have a minimum resolution of 200 pixels in the smallest axis"
+        After normalization, the images will have dimension 200x200.
+        See data/README.md for more info
     '''
     # TODO: Not sure if the images should be truncated to a common size, or padded, etc etc
     return []
@@ -42,7 +44,8 @@ def load_train_data():
         :returns: (annotations, imgs)
     '''
     paths = get_img_paths("TrainImages.txt")
-    return load_annotations(paths), load_images(paths)
+    # return load_annotations(paths), load_images(paths)
+    return load_images(paths)
 
 
 def load_test_data():
@@ -52,4 +55,5 @@ def load_test_data():
         :returns: (annotations, imgs)
     '''
     paths = get_img_paths("TestImages.txt")
-    return load_annotations(paths), load_images(paths)
+    # return load_annotations(paths), load_images(paths)
+    return load_images(paths)

--- a/load_data.py
+++ b/load_data.py
@@ -82,21 +82,28 @@ def load_images(paths):
 
 def load_train_data():
     '''
-        Returns the images and annotations for the train images
+        Returns the train images. If npy file not there, will be generated
         
-        :returns: (annotations, imgs)
     '''
+    outpath = "TrainImages.npy"
+    full_outpath = os.path.abspath(os.path.join(data_dir, outpath))
+    if os.path.exists(full_outpath):
+        return np.load(full_outpath)
     paths = get_img_paths("TrainImages.txt")
-    # return load_annotations(paths), load_images(paths)
-    return load_images(paths)
+    train_data = load_images(paths)
+    np.save(full_outpath, train_data)
+    return train_data
 
 
 def load_test_data():
     '''
-        Returns the images and annotations for the test images
-                
-        :returns: (annotations, imgs)
+        Returns the test images. If npy file not there, will be generated
     '''
+    outpath = "TestImages.npy"
+    full_outpath = os.path.abspath(os.path.join(data_dir, outpath))
+    if os.path.exists(full_outpath):
+        return np.load(full_outpath)
     paths = get_img_paths("TestImages.txt")
-    # return load_annotations(paths), load_images(paths)
-    return load_images(paths)
+    train_data = load_images(paths)
+    np.save(full_outpath, train_data)
+    return train_data

--- a/load_data.py
+++ b/load_data.py
@@ -1,77 +1,53 @@
-import zipfile
-import tarfile
 import numpy as np
 import os
 
-PREFIX = "digit_"
+data_dir = './data/'
 
-TEST_STEM = "test_"
-TRAIN_STEM = "train_"
-
-def check_and_extract_zipfile(filename, data_dir):
-    if os.path.isdir(data_dir) and not os.listdir(data_dir):
-        pass
-    else:
-        zip_f = zipfile.ZipFile(filename, 'r')
-        zip_f.extractall(data_dir)
-        zip_f.close()
-
-def load_data(data_dir, stem):
-    """
-    Loads data from either the training set or the test set and returns the pixel values and
-    class labels
-    """
-    data = []
-    labels = []
-    for i in range(0, 10):
-        path = os.path.join(data_dir, PREFIX + stem + str(i) + ".txt")
-        digits = np.loadtxt(path, delimiter=',')
-        digit_count = digits.shape[0]
-        data.append(digits)
-        labels.append(np.ones(digit_count) * i)
-    data, labels = np.array(data), np.array(labels)
-    data = np.reshape(data, (-1, 64))
-    labels = np.reshape(labels, (-1))
-    return data, labels
-
-def load_all_data(data_dir, shuffle=True):
+def get_img_paths(name):
     '''
-    Loads all data from the given data directory.
-
-    Returns four numpy arrays:
-        - train_data
-        - train_labels
-        - test_data
-        - test_labels
+        Returns a list of image paths which are found in name file
     '''
-    if not os.path.isdir(data_dir):
-        raise OSError('Data directory {} does not exist. Try "load_all_data_from_zip" function first.'.format(data_dir))
+    ret = []
+    with open(data_dir+name, 'r') as reader:
+        ret = reader.readlines()
+    return ret
 
-    train_data, train_labels = load_data(data_dir, TRAIN_STEM)
-    test_data, test_labels = load_data(data_dir, TEST_STEM)
 
-    if shuffle:
-        train_indices = np.random.permutation(train_data.shape[0])
-        test_indices = np.random.permutation(test_data.shape[0])
-        train_data, train_labels = train_data[train_indices], train_labels[train_indices]
-        test_data, test_labels = test_data[test_indices], test_labels[test_indices]
-
-    return train_data, train_labels, test_data, test_labels
-
-def load_all_data_from_zip(zipfile, data_dir, shuffle=True):
+def load_annotations(paths):
     '''
-    Unzips data in zipfile into folder data_dir, then returns all of the data.
-
-    Inputs:
-        - zipfile: string path to hw4digits.zip zipfile
-        - data_dir: path to directory to extract zip file
-        - shuffle: whether to randomly permute the data (true by default)
-
-    Returns four numpy arrays:
-        - train_data
-        - train_labels
-        - test_data
-        - test_labels
+        Returns list of annotations found in paths.
+        Per source of data:
+        "A subset of the images are segmented and annotated with the objects that they contain. The annotations are in LabelMe format."
     '''
-    check_and_extract_zipfile(zipfile, data_dir)
-    return load_all_data(data_dir, shuffle)
+    return []
+
+
+def load_images(paths):
+    '''
+        Returns a list of images found in paths.
+            The original images are all of different dimensions. 
+            The dimensions will be normalized before returning
+        Per source of data:
+        "All images have a minimum resolution of 200 pixels in the smallest axis"
+    '''
+    return []
+
+
+def load_train_data():
+    '''
+        Returns the images and annotations for the train images
+        
+        :returns: (annotations, imgs)
+    '''
+    paths = get_img_paths("TrainImages.txt")
+    return load_annotations(paths), load_images(paths)
+
+
+def load_test_data():
+    '''
+        Returns the images and annotations for the test images
+                
+        :returns: (annotations, imgs)
+    '''
+    paths = get_img_paths("TestImages.txt")
+    return load_annotations(paths), load_images(paths)

--- a/load_data.py
+++ b/load_data.py
@@ -1,0 +1,77 @@
+import zipfile
+import tarfile
+import numpy as np
+import os
+
+PREFIX = "digit_"
+
+TEST_STEM = "test_"
+TRAIN_STEM = "train_"
+
+def check_and_extract_zipfile(filename, data_dir):
+    if os.path.isdir(data_dir) and not os.listdir(data_dir):
+        pass
+    else:
+        zip_f = zipfile.ZipFile(filename, 'r')
+        zip_f.extractall(data_dir)
+        zip_f.close()
+
+def load_data(data_dir, stem):
+    """
+    Loads data from either the training set or the test set and returns the pixel values and
+    class labels
+    """
+    data = []
+    labels = []
+    for i in range(0, 10):
+        path = os.path.join(data_dir, PREFIX + stem + str(i) + ".txt")
+        digits = np.loadtxt(path, delimiter=',')
+        digit_count = digits.shape[0]
+        data.append(digits)
+        labels.append(np.ones(digit_count) * i)
+    data, labels = np.array(data), np.array(labels)
+    data = np.reshape(data, (-1, 64))
+    labels = np.reshape(labels, (-1))
+    return data, labels
+
+def load_all_data(data_dir, shuffle=True):
+    '''
+    Loads all data from the given data directory.
+
+    Returns four numpy arrays:
+        - train_data
+        - train_labels
+        - test_data
+        - test_labels
+    '''
+    if not os.path.isdir(data_dir):
+        raise OSError('Data directory {} does not exist. Try "load_all_data_from_zip" function first.'.format(data_dir))
+
+    train_data, train_labels = load_data(data_dir, TRAIN_STEM)
+    test_data, test_labels = load_data(data_dir, TEST_STEM)
+
+    if shuffle:
+        train_indices = np.random.permutation(train_data.shape[0])
+        test_indices = np.random.permutation(test_data.shape[0])
+        train_data, train_labels = train_data[train_indices], train_labels[train_indices]
+        test_data, test_labels = test_data[test_indices], test_labels[test_indices]
+
+    return train_data, train_labels, test_data, test_labels
+
+def load_all_data_from_zip(zipfile, data_dir, shuffle=True):
+    '''
+    Unzips data in zipfile into folder data_dir, then returns all of the data.
+
+    Inputs:
+        - zipfile: string path to hw4digits.zip zipfile
+        - data_dir: path to directory to extract zip file
+        - shuffle: whether to randomly permute the data (true by default)
+
+    Returns four numpy arrays:
+        - train_data
+        - train_labels
+        - test_data
+        - test_labels
+    '''
+    check_and_extract_zipfile(zipfile, data_dir)
+    return load_all_data(data_dir, shuffle)

--- a/playground.py
+++ b/playground.py
@@ -1,5 +1,7 @@
 import tarfile
 import load_data
+import cv2
+import numpy as np
 
 ###############################
 # Untar data
@@ -17,7 +19,14 @@ def untar_data(name, outdir='./data'):
 # Load data
 test_data = load_data.load_test_data()
 train_data = load_data.load_train_data()
+
+# Show the data
 print(test_data.shape)
 print(train_data.shape)
+train_i = np.random.choice(train_data.shape[0])
+test_i = np.random.choice(test_data.shape[0])
+cv2.imshow("example in train", train_data[train_i])
+cv2.imshow("example in test", test_data[test_i])
+cv2.waitKey(0)
 
 ###############################

--- a/playground.py
+++ b/playground.py
@@ -1,1 +1,11 @@
-# Python file to test/play around with code
+import tarfile
+
+def untar_data(name, outdir='./data'):
+    my_tar = tarfile.open('./Indoor-scene-recognition/'+name)
+    my_tar.extractall(outdir)
+    my_tar.close()
+
+
+# Uncomment to untar data
+# untar_data("indoorCVPR_09annotations.tar")
+# untar_data("indoorCVPR_09.tar")

--- a/playground.py
+++ b/playground.py
@@ -1,4 +1,5 @@
 import tarfile
+import load_data
 
 ###############################
 # Untar data
@@ -10,4 +11,9 @@ def untar_data(name, outdir='./data'):
 # Uncomment to untar data
 # untar_data("indoorCVPR_09annotations.tar")
 # untar_data("indoorCVPR_09.tar")
+###############################
+
+###############################
+# Load data
+
 ###############################

--- a/playground.py
+++ b/playground.py
@@ -1,0 +1,1 @@
+# Python file to test/play around with code

--- a/playground.py
+++ b/playground.py
@@ -15,5 +15,9 @@ def untar_data(name, outdir='./data'):
 
 ###############################
 # Load data
+test_data = load_data.load_test_data()
+train_data = load_data.load_train_data()
+print(test_data.shape)
+print(train_data.shape)
 
 ###############################

--- a/playground.py
+++ b/playground.py
@@ -1,11 +1,13 @@
 import tarfile
 
+###############################
+# Untar data
 def untar_data(name, outdir='./data'):
     my_tar = tarfile.open('./Indoor-scene-recognition/'+name)
     my_tar.extractall(outdir)
     my_tar.close()
 
-
 # Uncomment to untar data
 # untar_data("indoorCVPR_09annotations.tar")
 # untar_data("indoorCVPR_09.tar")
+###############################


### PR DESCRIPTION
I implemented a utility file to load data so we can all be working with the same data.

The functionality is in load_data.py but I left example calls in playground.py

Essentially, to retrieve train data, call load_data.load_train_data() and to retrieve test data, call load_data.load_test_data()  (data must be untarred first).
if you haven't untarred  the .tar from source yet, you can untar using code in playground.py as well.

If its the first time loading the data, they will be save to .npy files. If it is not the first time, the data will be taken directly from .npy files. 

Also, since the images were all of different sizes, i normalized before returning (and saving) it. Basically, all the images are now 200x200 (see data/README.md for more info)
